### PR TITLE
swoop caboose configuration and handling

### DIFF
--- a/cmd/caboose.go
+++ b/cmd/caboose.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"log"
 
+	"github.com/element84/swoop-go/pkg/caboose"
+
+	"github.com/element84/swoop-go/pkg/cmdutil"
+	"github.com/element84/swoop-go/pkg/config"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-
-	"github.com/element84/swoop-go/pkg/caboose"
-	"github.com/element84/swoop-go/pkg/cmdutil"
 )
 
 func init() {
@@ -16,7 +17,7 @@ func init() {
 
 func mkCabooseCmd() *cobra.Command {
 	var (
-		config string
+		configFile string
 	)
 
 	cmd := &cobra.Command{
@@ -24,7 +25,7 @@ func mkCabooseCmd() *cobra.Command {
 		Short: "swoop-caboose commands for state updates",
 	}
 	cmd.PersistentFlags().StringVarP(
-		&config, "config-file", "f", "", "swoop-caboose config file path (required; SWOOP_CONFIG_FILE)",
+		&configFile, "config-file", "f", "", "swoop-caboose config file path (required; SWOOP_CONFIG_FILE)",
 	)
 	cmd.MarkPersistentFlagRequired("config-file")
 
@@ -34,8 +35,13 @@ func mkCabooseCmd() *cobra.Command {
 			Use:   "argo",
 			Short: "Run the caboose service for argo workflow integrations",
 			Run: func(cmd *cobra.Command, args []string) {
-				err := cmdutil.Run(&caboose.ArgoCaboose{
-					ConfigFile:     config,
+				sc, err := config.Parse(configFile)
+				if err != nil {
+					log.Fatalf("Error parsing config: %s", err)
+
+				}
+				err = cmdutil.Run(&caboose.ArgoCaboose{
+					SwoopConfig:    sc,
 					K8sConfigFlags: configFlags,
 				})
 				if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/element84/swoop-go/pkg/config"
+)
+
+func init() {
+	rootCmd.AddCommand(mkConfigCmd())
+}
+
+func mkConfigCmd() *cobra.Command {
+	var (
+		configFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "swoop command to verify/dump parsed config",
+		Run: func(cmd *cobra.Command, args []string) {
+			swoopConf, err := config.Parse(configFile)
+			if err != nil {
+				log.Fatalf("error: %v", err)
+			}
+
+			d, err := yaml.Marshal(swoopConf)
+			if err != nil {
+				log.Fatalf("error: %v", err)
+			}
+
+			fmt.Printf("%s\n", string(d))
+		},
+	}
+	cmd.PersistentFlags().StringVarP(
+		&configFile, "config-file", "f", "", "swoop config file path (required; SWOOP_CONFIG_FILE)",
+	)
+	cmd.MarkPersistentFlagRequired("config-file")
+
+	return cmd
+}

--- a/fixtures/swoop-config.yml
+++ b/fixtures/swoop-config.yml
@@ -1,12 +1,12 @@
 handlers:
   argoHandler:
     type: argoWorkflowHandler
-    #server-url: https://kubernetes:6443
+    #serverUrl: https://kubernetes:6443
     #token: {secrets.argo_token}
 
   cirrusHandler:
     type: cirrusWorkflowHandler
-    #sqs-url: https://sqs.aws.com/0142354653636::sqs::queue
+    #sqsUrl: https://sqs.aws.com/0142354653636::sqs::queue
 
   # We believe it is best to re-template the request
   # (at least with regard to secrets) JIT for every request execution
@@ -35,10 +35,9 @@ handlers:
         path: /secrets-mount/username-secret
         ttl: 1200
     headers:
-      - name: Authorization
-        value: "Basic {{ .secrets.user }} {{ .secrets.password}}"
-      - Content-Type: application/json
-      - X-Workflow-Name: "{{ .parameters.workflow_name }}"
+      Authorization: "Basic {{ .secrets.user }} {{ .secrets.password}}"
+      Content-Type: "application/json"
+      X-Workflow-Name: "{{ .parameters.workflow_name }}"
     backoff:
       retries: 10
       seconds: 5
@@ -56,12 +55,11 @@ handlers:
     # conductor will have the callback action_uuid so will be able to load the parameters.json
     # from object storage and use that for templating at request time
     parameters:
-      - name: workflow_name
+      workflow_name:
         # types?
         # how do we distinguish between default being set to null and it not being set at all?
-        required: false
         default: a_value # setting a default makes a parameter not required
-      - name: feature
+      feature:
 
 conductors:
   instance-a:
@@ -81,15 +79,15 @@ callbacks:
       - "timed_out"
     notOn:
       - "success"
-    feature_filter: <jsonpath like workflow chaining filter>
+    featureFilter: <jsonpath like workflow chaining filter>
     parameters:
-      - name: workflow_name
+      workflow_name:
         # TODO: need to add the workflow ID as a label on the workflow resource
         # this property name is invalid
         # Note these are _not_ templates, these are "select a value out of json"
         # see kubectl --sort-by=
         value: "{{ .workflow.resource.name -}}"
-      - name: feature
+      feature:
         value: "{{ .feature }}"
     enabled: true
 
@@ -110,9 +108,8 @@ workflows:
         handler: bulkUpdateHandler
         # single creates a single callback action
         type: single
-        when: ${workflow.status} == "success"
         # We could provide a filter, but if we want all items we can omit it
-        # feature_filter: <jsonpath like workflow chaining filter>
+        # featureFilter: <jsonpath like workflow chaining filter>
         enabled: false
   cirrus-example:
     callbacks:

--- a/fixtures/swoop-config.yml
+++ b/fixtures/swoop-config.yml
@@ -18,7 +18,7 @@ handlers:
     requestBody: |
       {
         "fixed": "a_value",
-        "name": "{{ .parameters.workflow_name -}}",
+        "name": "{{ .parameters.workflowName -}}",
         "date": "{{ .parameters.feature.properties.datetime -}}"
       }
     operation: POST
@@ -37,7 +37,7 @@ handlers:
     headers:
       Authorization: "Basic {{ .secrets.user }} {{ .secrets.password}}"
       Content-Type: "application/json"
-      X-Workflow-Name: "{{ .parameters.workflow_name }}"
+      X-Workflow-Name: "{{ .parameters.workflowName }}"
     backoff:
       retries: 10
       seconds: 5
@@ -55,7 +55,7 @@ handlers:
     # conductor will have the callback action_uuid so will be able to load the parameters.json
     # from object storage and use that for templating at request time
     parameters:
-      workflow_name:
+      workflowName:
         # types?
         # how do we distinguish between default being set to null and it not being set at all?
         default: a_value # setting a default makes a parameter not required
@@ -79,9 +79,9 @@ callbacks:
       - "timed_out"
     notOn:
       - "success"
-    featureFilter: <jsonpath like workflow chaining filter>
+    featureFilter: "@.id =~ 'fake*' & @.properties.gsd <= 0"
     parameters:
-      workflow_name:
+      workflowName:
         # TODO: need to add the workflow ID as a label on the workflow resource
         # this property name is invalid
         # Note these are _not_ templates, these are "select a value out of json"
@@ -109,7 +109,7 @@ workflows:
         # single creates a single callback action
         type: single
         # We could provide a filter, but if we want all items we can omit it
-        # featureFilter: <jsonpath like workflow chaining filter>
+        # featureFilter: "@.id =~ 'fake*' & @.properties.gsd <= 0"
         enabled: false
   cirrus-example:
     callbacks:

--- a/fixtures/swoop-config.yml
+++ b/fixtures/swoop-config.yml
@@ -59,6 +59,7 @@ handlers:
       - name: workflow_name
         # types?
         # how do we distinguish between default being set to null and it not being set at all?
+        required: false
         default: a_value # setting a default makes a parameter not required
       - name: feature
 
@@ -69,17 +70,17 @@ conductors:
       - publishS3Handler
 
 callbacks:
-  publishS3Push: &callbacks-publishS3Push
+  publishS3Push: &callbacksPublishS3Push
     handler: publishS3Handler
     # per_feature creates a callback action for each feature in the output
     type: perFeature
     on:
-      - always
-      - never
-      - not "success"
+      - "success"
       - "failed"
       - "aborted"
       - "timed_out"
+    notOn:
+      - "success"
     feature_filter: <jsonpath like workflow chaining filter>
     parameters:
       - name: workflow_name
@@ -90,6 +91,7 @@ callbacks:
         value: "{{ .workflow.resource.name -}}"
       - name: feature
         value: "{{ .feature }}"
+    enabled: true
 
 workflows:
   mirror:
@@ -102,7 +104,8 @@ workflows:
       - .features[].collection
     cacheKeyHashExcludes: []
     callbacks:
-      publish_s3_push: << *callbacks-publishS3Push
+      publishS3Push:
+        <<: *callbacksPublishS3Push
       bulkUpdate:
         handler: bulkUpdateHandler
         # single creates a single callback action
@@ -113,7 +116,8 @@ workflows:
         enabled: false
   cirrus-example:
     callbacks:
-      publish_s3_push: << *callbacks-publishS3Push
+      publishS3Push:
+        <<: *callbacksPublishS3Push
     title: "Cirrus example workflow"
     description: "An example workflow config for a cirrus workflow"
     version: 1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
-	k8s.io/apimachinery v0.27.2
+	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/apimachinery v0.27.1
 	k8s.io/cli-runtime v0.27.1
 	k8s.io/client-go v0.27.2
 )
@@ -113,8 +114,7 @@ require (
 	gopkg.in/jcmturner/gokrb5.v5 v5.3.0 // indirect
 	gopkg.in/jcmturner/rpc.v0 v0.0.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.27.2 // indirect
+	k8s.io/api v0.27.1 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/apimachinery v0.27.1
+	k8s.io/apimachinery v0.27.2
 	k8s.io/cli-runtime v0.27.1
 	k8s.io/client-go v0.27.2
 )
@@ -114,7 +114,7 @@ require (
 	gopkg.in/jcmturner/gokrb5.v5 v5.3.0 // indirect
 	gopkg.in/jcmturner/rpc.v0 v0.0.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/api v0.27.1 // indirect
+	k8s.io/api v0.27.2 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect

--- a/pkg/config/parsing.go
+++ b/pkg/config/parsing.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v3"
+)
+
+type SwoopConfig struct {
+	Workflows map[string]Workflow `yaml:"workflows"`
+	Handlers  map[string]Handler  `yaml:"handlers"`
+}
+
+// Callback structs
+type CallbackParameter struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+type Callback struct {
+	Handler       string              `yaml:"handler"`
+	Type          string              `yaml:"type"`
+	FeatureFilter string              `yaml:"feature_filter,omitempty"`
+	When          string              `yaml:"when,omitempty"`
+	Enabled       bool                `yaml:"enabled,omitempty"`
+	Parameters    []CallbackParameter `yaml:"parameters,omitempty"`
+}
+
+type Workflow struct {
+	Callbacks map[string]Callback `yaml:"callbacks"`
+}
+
+// Handler structs
+type Handler struct {
+	Type        string             `yaml:"type,omitempty"`
+	Url         string             `yaml:"url,omitempty"`
+	RequestBody string             `yaml:"requestBody,omitempty"`
+	Operation   string             `yaml:"operation,omitempty"`
+	Secrets     []Secret           `yaml:"secrets,omitempty"`
+	Headers     []Header           `yaml:"headers,omitempty"`
+	Backoff     map[string]int     `yaml:"backoff,omitempty"`
+	Errors      []Error            `yaml:"errors,omitempty"`
+	Parameters  []HandlerParameter `yaml:"parameters,omitempty"`
+}
+
+type Secret struct {
+	Name string `yaml:"name,omitempty"`
+	Type string `yaml:"type,omitempty"`
+	Path string `yaml:"path,omitempty"`
+	TTL  int    `yaml:"ttl,omitempty"`
+}
+
+type Header struct {
+	Name          string `yaml:"name,omitempty"`
+	Value         string `yaml:"value,omitempty"`
+	ContentType   string `yaml:"Content-Type,omitempty"`
+	XWorkflowName string `yaml:"X-Workflow-Name,omitempty"`
+}
+
+type Error struct {
+	Status    int    `yaml:"status,omitempty"`
+	Message   string `yaml:"message,omitempty"`
+	Retryable string `yaml:"retryable,omitempty"`
+}
+
+type HandlerParameter struct {
+	Name    string `yaml:"name,omitempty"`
+	Default string `yaml:"default,omitempty"`
+}
+
+func loadYaml(inputFile string, conf *SwoopConfig) error {
+	readFile, err := ioutil.ReadFile(inputFile)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(readFile, conf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Parse(configFile string) (*SwoopConfig, error) {
+	conf := &SwoopConfig{}
+	err := loadYaml(configFile, conf)
+	return conf, err
+}

--- a/pkg/config/parsing.go
+++ b/pkg/config/parsing.go
@@ -166,8 +166,3 @@ func Parse(configFile string) (*SwoopConfig, error) {
 	}
 	return conf, nil
 }
-
-func main() {
-	Parse("./fixtures/swoop-config.yml")
-
-}

--- a/pkg/config/parsing.go
+++ b/pkg/config/parsing.go
@@ -1,29 +1,34 @@
+// package config
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
+
+	"github.com/element84/swoop-go/pkg/utils"
 
 	"gopkg.in/yaml.v3"
 )
 
 type SwoopConfig struct {
-	Workflows map[string]Workflow `yaml:"workflows"`
-	Handlers  map[string]Handler  `yaml:"handlers"`
+	Workflows  map[string]Workflow  `yaml:"workflows"`
+	Handlers   map[string]Handler   `yaml:"handlers"`
+	Conductors map[string]Conductor `yaml:"conductors"`
 }
 
 // Callback structs
 type CallbackParameter struct {
-	Name  string `yaml:"name"`
 	Value string `yaml:"value"`
 }
 
 type Callback struct {
-	Handler       string              `yaml:"handler"`
-	Type          string              `yaml:"type"`
-	FeatureFilter string              `yaml:"feature_filter,omitempty"`
-	When          string              `yaml:"when,omitempty"`
-	Enabled       bool                `yaml:"enabled,omitempty"`
-	Parameters    []CallbackParameter `yaml:"parameters,omitempty"`
+	Handler       string                       `yaml:"handler"`
+	Type          string                       `yaml:"type"`
+	FeatureFilter string                       `yaml:"feature_filter,omitempty"`
+	On            []string                     `yaml:"on,omitempty"`
+	NotOn         []string                     `yaml:"notOn,omitempty"`
+	Enabled       bool                         `yaml:"enabled,omitempty"`
+	Parameters    map[string]CallbackParameter `yaml:"parameters,omitempty"`
 }
 
 type Workflow struct {
@@ -32,15 +37,15 @@ type Workflow struct {
 
 // Handler structs
 type Handler struct {
-	Type        string             `yaml:"type,omitempty"`
-	Url         string             `yaml:"url,omitempty"`
-	RequestBody string             `yaml:"requestBody,omitempty"`
-	Operation   string             `yaml:"operation,omitempty"`
-	Secrets     []Secret           `yaml:"secrets,omitempty"`
-	Headers     []Header           `yaml:"headers,omitempty"`
-	Backoff     map[string]int     `yaml:"backoff,omitempty"`
-	Errors      []Error            `yaml:"errors,omitempty"`
-	Parameters  []HandlerParameter `yaml:"parameters,omitempty"`
+	Type        string                      `yaml:"type,omitempty"`
+	Url         string                      `yaml:"url,omitempty"`
+	RequestBody string                      `yaml:"requestBody,omitempty"`
+	Operation   string                      `yaml:"operation,omitempty"`
+	Secrets     []Secret                    `yaml:"secrets,omitempty"`
+	Headers     map[string]string           `yaml:"headers,omitempty"`
+	Backoff     map[string]int              `yaml:"backoff,omitempty"`
+	Errors      []Error                     `yaml:"errors,omitempty"`
+	Parameters  map[string]HandlerParameter `yaml:"parameters,omitempty"`
 }
 
 type Secret struct {
@@ -50,13 +55,6 @@ type Secret struct {
 	TTL  int    `yaml:"ttl,omitempty"`
 }
 
-type Header struct {
-	Name          string `yaml:"name,omitempty"`
-	Value         string `yaml:"value,omitempty"`
-	ContentType   string `yaml:"Content-Type,omitempty"`
-	XWorkflowName string `yaml:"X-Workflow-Name,omitempty"`
-}
-
 type Error struct {
 	Status    int    `yaml:"status,omitempty"`
 	Message   string `yaml:"message,omitempty"`
@@ -64,8 +62,14 @@ type Error struct {
 }
 
 type HandlerParameter struct {
-	Name    string `yaml:"name,omitempty"`
-	Default string `yaml:"default,omitempty"`
+	isDefaultSet bool
+	Default      interface{} `yaml:"default,omitempty"`
+}
+
+// Conductor structs
+
+type Conductor struct {
+	Handlers []string `yaml:"handlers,omitempty"`
 }
 
 func loadYaml(inputFile string, conf *SwoopConfig) error {
@@ -82,8 +86,88 @@ func loadYaml(inputFile string, conf *SwoopConfig) error {
 	return nil
 }
 
+func ValidateConfig(sc *SwoopConfig) error {
+
+	for wf_name, wf := range sc.Workflows {
+		for cb_name, cb := range wf.Callbacks {
+
+			// Check for conflicts in on/not on conditions
+
+			on := cb.On
+			notOn := cb.NotOn
+			for _, v := range on {
+				if utils.Contains(notOn, v) {
+					err := fmt.Errorf("the workflow status value '%v' for callback '%s' in workflow '%s' is conflicting and appears in both the on/ notOn clauses in the config", v, cb_name, wf_name)
+					fmt.Println(err)
+				}
+			}
+
+			callback_params := cb.Parameters
+			handler_name := cb.Handler
+			handler_params := sc.Handlers[handler_name].Parameters
+			var callback_param_names []string
+			var handler_param_names []string
+
+			for hand_name, hand_param := range handler_params {
+				if hand_param.IsRequired() {
+					handler_param_names = append(handler_param_names, hand_name)
+				}
+			}
+
+			for cb_name := range callback_params {
+				callback_param_names = append(callback_param_names, cb_name)
+			}
+
+			// Check if all required handler parameters are defined in callback
+			for _, v := range handler_param_names {
+				if !utils.Contains(callback_param_names, v) {
+					return fmt.Errorf("required handler parameter '%s' is not provided as a callback parameter for callback '%s' in workflow '%s' ", v, cb_name, wf_name)
+				}
+			}
+
+			// Check if no additional callback parameters are defined that are not also required handler parameters
+			if len(callback_param_names) != len(handler_param_names) {
+				return fmt.Errorf("the number of callback parameters (%d) is not equal to the number of required handler parameters (%d) for callback %s in workflow '%s'", len(callback_param_names), len(handler_param_names), cb_name, wf_name)
+			}
+
+		}
+	}
+
+	return nil
+
+}
+
+func (p *HandlerParameter) IsRequired() bool {
+	return !p.isDefaultSet
+}
+
+func (p *HandlerParameter) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var iface map[string]interface{}
+	var ok bool
+	err := unmarshal(&iface)
+	fmt.Println(err)
+	p.isDefaultSet = false
+	p.Default, ok = iface["default"]
+	if ok {
+		p.isDefaultSet = true
+	}
+	return nil
+}
+
 func Parse(configFile string) (*SwoopConfig, error) {
 	conf := &SwoopConfig{}
 	err := loadYaml(configFile, conf)
-	return conf, err
+	if err != nil {
+		return nil, err
+	}
+	err = ValidateConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+	return conf, nil
+}
+
+func main() {
+	Parse("./fixtures/swoop-config.yml")
+
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,11 @@
+package utils
+
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Handling callback properties on/notOn, not when

Review config and make any snake_case keys camelCase

Load the swoop config into structs and can access the caboose-relevant portions within the caboose code where needed (argoCabooseRunner.wfDone())

**Parameter validation**

For each workflow’s callback’s parameters, validate that all of that callback’s handler’s required parameters are defined, and that no additional parameters are defined

Any missing required parameters is a parsing error

Any extra parameters not supported by the handler is a parsing error

Also consider how we can determine if a parameter is required or not

Differentiate between default: null and default being unset.

on/notOn, validating those values (error on conflict)

how to compare those to a workflow’s state: a function that takes a workflowProperties instance and compares its state value to those in on/notOn to return whether the callback should be run base on the workflow’s state, returning a bool

Example demonstrating the use of JsonPath filters for the `featureFilter` parameter